### PR TITLE
Implement database persistence and reward claiming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# EventPlugin
+
+Prototype plugin implementing basic event progress system for Paper 1.20.1.
+
+## Features
+
+* Toggleable progress event with `/event toggle`.
+* MythicMobs kills add random progress (0-5) and honour `Event Attrie` buff (+50%).
+* Simple GUI to display player progress and configured rewards (`/event gui`).
+* Admin command to add rewards from held item: `/event addreward <progress>`.
+* Attrie item activation via right click (30 day buff).
+* MySQL connection configuration in `config.yml`.
+
+This implementation is minimal and meant as a starting point based on the
+conversation specification.

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,10 @@
             <id>sonatype</id>
             <url>https://oss.sonatype.org/content/groups/public/</url>
         </repository>
+        <repository>
+            <id>lumine-repo</id>
+            <url>https://mvn.lumine.io/repository/maven-public/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -67,6 +71,17 @@
             <artifactId>paper-api</artifactId>
             <version>1.20.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.lumine</groupId>
+            <artifactId>Mythic-Dist</artifactId>
+            <version>5.5.0-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>5.0.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/org/maks/eventPlugin/EventPlugin.java
+++ b/src/main/java/org/maks/eventPlugin/EventPlugin.java
@@ -1,17 +1,57 @@
 package org.maks.eventPlugin;
 
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.command.PluginCommand;
+import org.maks.eventPlugin.command.EventCommand;
+import org.maks.eventPlugin.config.ConfigManager;
+import org.maks.eventPlugin.db.DatabaseManager;
+import org.maks.eventPlugin.eventsystem.BuffManager;
+import org.maks.eventPlugin.eventsystem.EventManager;
+import org.maks.eventPlugin.gui.PlayerProgressGUI;
+import org.maks.eventPlugin.listener.AttrieItemListener;
+import org.maks.eventPlugin.listener.MythicMobProgressListener;
 
 public final class EventPlugin extends JavaPlugin {
+    private ConfigManager configManager;
+    private DatabaseManager databaseManager;
+    private EventManager eventManager;
+    private BuffManager buffManager;
+    private PlayerProgressGUI progressGUI;
 
     @Override
     public void onEnable() {
-        // Plugin startup logic
+        saveDefaultConfig();
+        configManager = new ConfigManager(this);
+        configManager.load();
 
+        String host = configManager.getString("database.host");
+        String port = configManager.getString("database.port");
+        String db = configManager.getString("database.name");
+        String user = configManager.getString("database.user");
+        String pass = configManager.getString("database.password");
+
+        databaseManager = new DatabaseManager();
+        databaseManager.connect(host, port, db, user, pass);
+        databaseManager.setupTables();
+        eventManager = new EventManager(databaseManager);
+        buffManager = new BuffManager(databaseManager);
+        progressGUI = new PlayerProgressGUI(eventManager);
+
+        getServer().getPluginManager().registerEvents(new MythicMobProgressListener(eventManager, buffManager), this);
+        getServer().getPluginManager().registerEvents(new AttrieItemListener(this, buffManager), this);
+        getServer().getPluginManager().registerEvents(progressGUI, this);
+
+        PluginCommand cmd = getCommand("event");
+        if (cmd != null) {
+            cmd.setExecutor(new EventCommand(eventManager, progressGUI));
+        } else {
+            Bukkit.getLogger().warning("Event command not found in plugin.yml");
+        }
     }
 
     @Override
     public void onDisable() {
-        // Plugin shutdown logic
+        if (databaseManager != null) databaseManager.close();
     }
 }

--- a/src/main/java/org/maks/eventPlugin/command/EventCommand.java
+++ b/src/main/java/org/maks/eventPlugin/command/EventCommand.java
@@ -1,0 +1,60 @@
+package org.maks.eventPlugin.command;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.maks.eventPlugin.eventsystem.EventManager;
+import org.maks.eventPlugin.gui.PlayerProgressGUI;
+
+public class EventCommand implements CommandExecutor {
+    private final EventManager eventManager;
+    private final PlayerProgressGUI gui;
+
+    public EventCommand(EventManager eventManager, PlayerProgressGUI gui) {
+        this.eventManager = eventManager;
+        this.gui = gui;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length == 0) return false;
+        switch (args[0].toLowerCase()) {
+            case "toggle" -> {
+                if (!sender.hasPermission("eventplugin.admin")) return true;
+                eventManager.toggle();
+                sender.sendMessage("Event toggled. Active: " + eventManager.isActive());
+            }
+            case "gui" -> {
+                if (sender instanceof Player player) {
+                    gui.open(player);
+                }
+            }
+            case "addreward" -> {
+                if (!(sender instanceof Player player)) return true;
+                if (!sender.hasPermission("eventplugin.admin")) return true;
+                if (args.length < 2) {
+                    sender.sendMessage("Usage: /event addreward <progress>");
+                    return true;
+                }
+                int prog;
+                try {
+                    prog = Integer.parseInt(args[1]);
+                } catch (NumberFormatException e) {
+                    sender.sendMessage("Invalid number");
+                    return true;
+                }
+                ItemStack item = player.getInventory().getItemInMainHand();
+                if (item.getType().isAir()) {
+                    sender.sendMessage("Hold the reward item in your hand");
+                    return true;
+                }
+                eventManager.addReward(prog, item.clone());
+                sender.sendMessage("Reward added for progress " + prog);
+            }
+            default -> sender.sendMessage("Unknown subcommand");
+        }
+        return true;
+    }
+}

--- a/src/main/java/org/maks/eventPlugin/config/ConfigManager.java
+++ b/src/main/java/org/maks/eventPlugin/config/ConfigManager.java
@@ -1,0 +1,34 @@
+package org.maks.eventPlugin.config;
+
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.io.IOException;
+
+public class ConfigManager {
+    private final JavaPlugin plugin;
+    private FileConfiguration config;
+
+    public ConfigManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public void load() {
+        File configFile = new File(plugin.getDataFolder(), "config.yml");
+        if (!configFile.exists()) {
+            configFile.getParentFile().mkdirs();
+            plugin.saveResource("config.yml", false);
+        }
+        config = YamlConfiguration.loadConfiguration(configFile);
+    }
+
+    public FileConfiguration getConfig() {
+        return config;
+    }
+
+    public String getString(String path) {
+        return config.getString(path);
+    }
+}

--- a/src/main/java/org/maks/eventPlugin/db/DatabaseManager.java
+++ b/src/main/java/org/maks/eventPlugin/db/DatabaseManager.java
@@ -1,0 +1,56 @@
+package org.maks.eventPlugin.db;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.bukkit.Bukkit;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public class DatabaseManager {
+    private HikariDataSource dataSource;
+
+    public void connect(String host, String port, String database, String user, String password) {
+        HikariConfig config = new HikariConfig();
+        config.setJdbcUrl("jdbc:mysql://" + host + ":" + port + "/" + database + "?useSSL=false&allowPublicKeyRetrieval=true");
+        config.setUsername(user);
+        config.setPassword(password);
+        config.addDataSourceProperty("cachePrepStmts", "true");
+        config.addDataSourceProperty("prepStmtCacheSize", "250");
+        config.addDataSourceProperty("prepStmtCacheSqlLimit", "2048");
+        dataSource = new HikariDataSource(config);
+        Bukkit.getLogger().info("[EventPlugin] Connected to MySQL");
+    }
+
+    public Connection getConnection() throws SQLException {
+        return dataSource.getConnection();
+    }
+
+    /**
+     * Create tables used by the plugin if they don't exist.
+     */
+    public void setupTables() {
+        try (Connection conn = getConnection();
+             var st = conn.createStatement()) {
+            st.executeUpdate("CREATE TABLE IF NOT EXISTS event_progress(" +
+                    "player_uuid VARCHAR(36) PRIMARY KEY," +
+                    "progress INT NOT NULL," +
+                    "buff_end BIGINT NOT NULL DEFAULT 0)");
+            st.executeUpdate("CREATE TABLE IF NOT EXISTS event_rewards(" +
+                    "required INT PRIMARY KEY," +
+                    "item TEXT NOT NULL)");
+            st.executeUpdate("CREATE TABLE IF NOT EXISTS event_claimed(" +
+                    "player_uuid VARCHAR(36)," +
+                    "reward INT," +
+                    "PRIMARY KEY(player_uuid, reward))");
+        } catch (SQLException ex) {
+            Bukkit.getLogger().severe("[EventPlugin] Could not setup database tables: " + ex.getMessage());
+        }
+    }
+
+    public void close() {
+        if (dataSource != null) {
+            dataSource.close();
+        }
+    }
+}

--- a/src/main/java/org/maks/eventPlugin/eventsystem/BuffManager.java
+++ b/src/main/java/org/maks/eventPlugin/eventsystem/BuffManager.java
@@ -1,0 +1,67 @@
+package org.maks.eventPlugin.eventsystem;
+
+import org.bukkit.entity.Player;
+import org.maks.eventPlugin.db.DatabaseManager;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Manages the attrie buff for players.
+ */
+import java.sql.SQLException;
+
+public class BuffManager {
+    private final Map<UUID, Instant> buffEnd = new HashMap<>();
+    private final DatabaseManager database;
+
+    public BuffManager(DatabaseManager database) {
+        this.database = database;
+        loadBuffs();
+    }
+
+    public boolean hasBuff(Player player) {
+        Instant end = buffEnd.get(player.getUniqueId());
+        return end != null && end.isAfter(Instant.now());
+    }
+
+    public void applyBuff(Player player, int days) {
+        Instant end = Instant.now().plusSeconds(days * 24L * 3600L);
+        buffEnd.put(player.getUniqueId(), end);
+        saveBuff(player.getUniqueId(), end);
+    }
+
+    private void loadBuffs() {
+        try (var conn = database.getConnection();
+             var ps = conn.prepareStatement("SELECT player_uuid, buff_end FROM event_progress")) {
+            try (var rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    UUID id = UUID.fromString(rs.getString(1));
+                    long end = rs.getLong(2);
+                    if (end > 0) buffEnd.put(id, Instant.ofEpochMilli(end));
+                }
+            }
+        } catch (SQLException ignored) {
+        }
+    }
+
+    private void saveBuff(UUID uuid, Instant end) {
+        long millis = end.toEpochMilli();
+        try (var conn = database.getConnection();
+             var ps = conn.prepareStatement("UPDATE event_progress SET buff_end=? WHERE player_uuid=?")) {
+            ps.setLong(1, millis);
+            ps.setString(2, uuid.toString());
+            if (ps.executeUpdate() == 0) {
+                try (var ins = conn.prepareStatement("INSERT INTO event_progress(player_uuid, progress, buff_end) VALUES (?,?,?)")) {
+                    ins.setString(1, uuid.toString());
+                    ins.setInt(2, 0);
+                    ins.setLong(3, millis);
+                    ins.executeUpdate();
+                }
+            }
+        } catch (SQLException ignored) {
+        }
+    }
+}

--- a/src/main/java/org/maks/eventPlugin/eventsystem/EventManager.java
+++ b/src/main/java/org/maks/eventPlugin/eventsystem/EventManager.java
@@ -1,0 +1,146 @@
+package org.maks.eventPlugin.eventsystem;
+
+import org.bukkit.entity.Player;
+import org.maks.eventPlugin.db.DatabaseManager;
+import org.maks.eventPlugin.util.ItemUtil;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.List;
+import java.util.ArrayList;
+import org.bukkit.inventory.ItemStack;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class EventManager {
+    private final DatabaseManager database;
+    private boolean active = false;
+    private final int maxProgress = 25000; // hard-coded max progress
+    private final Map<UUID, Integer> progressMap = new HashMap<>();
+    private final Map<UUID, java.util.Set<Integer>> claimedMap = new HashMap<>();
+    private final List<Reward> rewards = new ArrayList<>();
+
+    public EventManager(DatabaseManager database) {
+        this.database = database;
+        loadRewards();
+        loadProgress();
+    }
+    public boolean isActive() {
+        return active;
+    }
+
+    public void toggle() {
+        active = !active;
+    }
+
+    public int getMaxProgress() {
+        return maxProgress;
+    }
+
+    public int getProgress(Player player) {
+        return progressMap.getOrDefault(player.getUniqueId(), 0);
+    }
+
+    public void addProgress(Player player, int amount, double multiplier) {
+        int current = progressMap.getOrDefault(player.getUniqueId(), 0);
+        int newProgress = current + (int) Math.round(amount * multiplier);
+        if (newProgress > maxProgress) newProgress = maxProgress;
+        progressMap.put(player.getUniqueId(), newProgress);
+        saveProgress(player.getUniqueId(), newProgress);
+    }
+
+    public void addReward(int required, ItemStack item) {
+        rewards.add(new Reward(required, item));
+        saveReward(required, item);
+    }
+
+    public List<Reward> getRewards() {
+        return rewards;
+    }
+
+    public boolean claimReward(Player player, int required) {
+        int progress = getProgress(player);
+        if (progress < required) return false;
+        var set = claimedMap.computeIfAbsent(player.getUniqueId(), k -> new java.util.HashSet<>());
+        if (set.contains(required)) return false;
+        set.add(required);
+        saveClaimed(player.getUniqueId(), required);
+        return true;
+    }
+
+    private void loadProgress() {
+        try (var conn = database.getConnection();
+             var ps = conn.prepareStatement("SELECT player_uuid, progress FROM event_progress")) {
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    UUID id = UUID.fromString(rs.getString(1));
+                    int prog = rs.getInt(2);
+                    progressMap.put(id, prog);
+                }
+            }
+        } catch (SQLException ignored) {
+        }
+        // load claimed rewards
+        try (var conn = database.getConnection();
+             var ps = conn.prepareStatement("SELECT player_uuid, reward FROM event_claimed")) {
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    UUID id = UUID.fromString(rs.getString(1));
+                    int rew = rs.getInt(2);
+                    claimedMap.computeIfAbsent(id, k -> new java.util.HashSet<>()).add(rew);
+                }
+            }
+        } catch (SQLException ignored) {
+        }
+    }
+
+    private void saveProgress(UUID uuid, int progress) {
+        try (var conn = database.getConnection();
+             var ps = conn.prepareStatement("REPLACE INTO event_progress(player_uuid, progress) VALUES (?,?)")) {
+            ps.setString(1, uuid.toString());
+            ps.setInt(2, progress);
+            ps.executeUpdate();
+        } catch (SQLException ignored) {
+        }
+    }
+
+    private void loadRewards() {
+        try (var conn = database.getConnection();
+             var ps = conn.prepareStatement("SELECT required, item FROM event_rewards")) {
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    int req = rs.getInt(1);
+                    String data = rs.getString(2);
+                    ItemStack item = ItemUtil.deserialize(data);
+                    if (item != null)
+                        rewards.add(new Reward(req, item));
+                }
+            }
+        } catch (SQLException ignored) {
+        }
+    }
+
+    private void saveReward(int required, ItemStack item) {
+        String data = ItemUtil.serialize(item);
+        if (data == null) return;
+        try (var conn = database.getConnection();
+             var ps = conn.prepareStatement("REPLACE INTO event_rewards(required, item) VALUES (?,?)")) {
+            ps.setInt(1, required);
+            ps.setString(2, data);
+            ps.executeUpdate();
+        } catch (SQLException ignored) {
+        }
+    }
+
+    private void saveClaimed(UUID uuid, int reward) {
+        try (var conn = database.getConnection();
+             var ps = conn.prepareStatement("REPLACE INTO event_claimed(player_uuid, reward) VALUES (?,?)")) {
+            ps.setString(1, uuid.toString());
+            ps.setInt(2, reward);
+            ps.executeUpdate();
+        } catch (SQLException ignored) {
+        }
+    }
+}

--- a/src/main/java/org/maks/eventPlugin/eventsystem/Reward.java
+++ b/src/main/java/org/maks/eventPlugin/eventsystem/Reward.java
@@ -1,0 +1,6 @@
+package org.maks.eventPlugin.eventsystem;
+
+import org.bukkit.inventory.ItemStack;
+
+public record Reward(int requiredProgress, ItemStack item) {
+}

--- a/src/main/java/org/maks/eventPlugin/gui/PlayerProgressGUI.java
+++ b/src/main/java/org/maks/eventPlugin/gui/PlayerProgressGUI.java
@@ -1,0 +1,80 @@
+package org.maks.eventPlugin.gui;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.maks.eventPlugin.eventsystem.EventManager;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class PlayerProgressGUI implements Listener {
+    private final EventManager eventManager;
+    private final Map<UUID, Inventory> open = new HashMap<>();
+
+    public PlayerProgressGUI(EventManager eventManager) {
+        this.eventManager = eventManager;
+    }
+
+    public void open(Player player) {
+        int size = 27;
+        Inventory inv = Bukkit.createInventory(null, size, "Event Progress");
+
+        int progress = eventManager.getProgress(player);
+        int max = eventManager.getMaxProgress();
+        int filledSlots = (int) ((double) progress / max * (size - 9));
+
+        ItemStack filled = new ItemStack(Material.YELLOW_STAINED_GLASS_PANE);
+        ItemMeta meta = filled.getItemMeta();
+        meta.setDisplayName("§eProgress " + progress + " / " + max);
+        filled.setItemMeta(meta);
+
+        ItemStack empty = new ItemStack(Material.BLACK_STAINED_GLASS_PANE);
+
+        for (int i = 0; i < size - 9; i++) {
+            inv.setItem(i, i < filledSlots ? filled : empty);
+        }
+
+        int index = size - 9;
+        for (var reward : eventManager.getRewards()) {
+            ItemStack rewardItem = reward.item().clone();
+            ItemMeta m = rewardItem.getItemMeta();
+            m.setDisplayName("§6Reward at " + reward.requiredProgress());
+            m.setLore(java.util.List.of("Requires: " + reward.requiredProgress()));
+            rewardItem.setItemMeta(m);
+            inv.setItem(index++, rewardItem);
+            if (index >= size) break;
+        }
+
+        open.put(player.getUniqueId(), inv);
+        player.openInventory(inv);
+    }
+
+    @EventHandler
+    public void onClick(InventoryClickEvent event) {
+        Player player = (Player) event.getWhoClicked();
+        Inventory inv = open.get(player.getUniqueId());
+        if (inv == null || !event.getInventory().equals(inv)) return;
+        event.setCancelled(true);
+        ItemStack item = event.getCurrentItem();
+        if (item == null) return;
+        for (var reward : eventManager.getRewards()) {
+            if (item.isSimilar(reward.item())) {
+                if (eventManager.claimReward(player, reward.requiredProgress())) {
+                    player.getInventory().addItem(reward.item().clone());
+                    player.sendMessage("§aReward claimed!");
+                } else {
+                    player.sendMessage("§cYou cannot claim this reward yet.");
+                }
+                break;
+            }
+        }
+    }
+}

--- a/src/main/java/org/maks/eventPlugin/listener/AttrieItemListener.java
+++ b/src/main/java/org/maks/eventPlugin/listener/AttrieItemListener.java
@@ -1,0 +1,35 @@
+package org.maks.eventPlugin.listener;
+
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.NamespacedKey;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.maks.eventPlugin.eventsystem.BuffManager;
+
+public class AttrieItemListener implements Listener {
+    private final BuffManager buffManager;
+    private final NamespacedKey key;
+
+    public AttrieItemListener(JavaPlugin plugin, BuffManager buffManager) {
+        this.buffManager = buffManager;
+        this.key = new NamespacedKey(plugin, "attrie-item");
+    }
+
+    @EventHandler
+    public void onInteract(PlayerInteractEvent event) {
+        Player player = event.getPlayer();
+        ItemStack item = event.getItem();
+        if (item == null || item.getType() == Material.AIR) return;
+        if (item.getItemMeta() != null && item.getItemMeta().getPersistentDataContainer().has(key, PersistentDataType.INTEGER)) {
+            event.setCancelled(true);
+            item.setAmount(item.getAmount() - 1);
+            buffManager.applyBuff(player, 30);
+            player.sendMessage("§aEvent Attrie activated for 30 days!");
+        }
+    }
+}

--- a/src/main/java/org/maks/eventPlugin/listener/MythicMobProgressListener.java
+++ b/src/main/java/org/maks/eventPlugin/listener/MythicMobProgressListener.java
@@ -1,0 +1,30 @@
+package org.maks.eventPlugin.listener;
+
+import io.lumine.mythic.bukkit.events.MythicMobDeathEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.entity.Player;
+import org.maks.eventPlugin.eventsystem.BuffManager;
+import org.maks.eventPlugin.eventsystem.EventManager;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+public class MythicMobProgressListener implements Listener {
+    private final EventManager eventManager;
+    private final BuffManager buffManager;
+
+    public MythicMobProgressListener(EventManager eventManager, BuffManager buffManager) {
+        this.eventManager = eventManager;
+        this.buffManager = buffManager;
+    }
+
+    @EventHandler
+    public void onMobDeath(MythicMobDeathEvent event) {
+        if (!eventManager.isActive()) return;
+        if (event.getKiller() instanceof Player player) {
+            int amount = ThreadLocalRandom.current().nextInt(0, 6);
+            double multiplier = buffManager.hasBuff(player) ? 1.5 : 1.0;
+            eventManager.addProgress(player, amount, multiplier);
+        }
+    }
+}

--- a/src/main/java/org/maks/eventPlugin/util/ItemUtil.java
+++ b/src/main/java/org/maks/eventPlugin/util/ItemUtil.java
@@ -1,0 +1,46 @@
+package org.maks.eventPlugin.util;
+
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.util.io.BukkitObjectInputStream;
+import org.bukkit.util.io.BukkitObjectOutputStream;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Base64;
+
+public class ItemUtil {
+    public static ItemStack createAttrieItem(JavaPlugin plugin) {
+        ItemStack item = new ItemStack(Material.POTATO);
+        ItemMeta meta = item.getItemMeta();
+        meta.setDisplayName("§3Event Attrie");
+        meta.getPersistentDataContainer().set(new NamespacedKey(plugin, "attrie-item"), PersistentDataType.INTEGER, 1);
+        meta.setUnbreakable(true);
+        item.setItemMeta(meta);
+        return item;
+    }
+
+    public static String serialize(ItemStack item) {
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream();
+             BukkitObjectOutputStream dataOut = new BukkitObjectOutputStream(out)) {
+            dataOut.writeObject(item);
+            return Base64.getEncoder().encodeToString(out.toByteArray());
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    public static ItemStack deserialize(String data) {
+        try (ByteArrayInputStream in = new ByteArrayInputStream(Base64.getDecoder().decode(data));
+             BukkitObjectInputStream dataIn = new BukkitObjectInputStream(in)) {
+            return (ItemStack) dataIn.readObject();
+        } catch (ClassNotFoundException | IOException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,6 @@
+database:
+  host: localhost
+  port: "3306"
+  name: database
+  user: user
+  password: pass

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -2,3 +2,7 @@ name: eventPlugin
 version: '1.0-SNAPSHOT'
 main: org.maks.eventPlugin.EventPlugin
 api-version: '1.20'
+commands:
+  event:
+    description: Main event command
+    usage: /event <toggle|gui|addreward>


### PR DESCRIPTION
## Summary
- create database tables for progress, rewards, and claimed rewards
- persist progress and attrie buffs in MySQL
- persist rewards and allow claiming them via GUI
- update item utility with serialization helpers
- register progress GUI listener

## Testing
- `mvn -q -DskipTests package` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_68887049dc78832a9981f28ae6129245