### PR TITLE
Implement configurable event loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# EventPlugin
+
+Prototype plugin implementing basic event progress system for Paper 1.20.1.
+
+## Features
+
+* Start and stop events via `/event start <id>` and `/event stop <id>`.
+* MythicMobs kills add progress according to per-event drop chances and honour `Event Attrie` buff (+50%).
+* Simple GUI to display player progress and configured rewards (`/event gui`).
+* Admin GUI to configure rewards with `/event rewards`.
+* Attrie item activation via right click (30 day buff).
+* Event metadata (name, description, duration) stored in MySQL `events` table.
+* MySQL connection configuration in `config.yml`.
+
+This implementation is minimal and meant as a starting point based on the
+conversation specification.
+
+## Example event configuration
+
+`config.yml` defines events under the `events` section. Example:
+
+```yaml
+events:
+  "1":
+    name: "Monster Hunt"
+    active: true
+    duration_days: 14
+    max_progress: 12000
+    description: "Monster hunt has begun, kill all monsters to get rewards."
+    drop_chances:
+      "0": 75
+      "1": 10
+      "2": 10
+      "3": 3
+      "5": 2
+```
+
+Drop chances are percentages for each progress value when a configured MythicMob dies.

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,10 @@
             <id>sonatype</id>
             <url>https://oss.sonatype.org/content/groups/public/</url>
         </repository>
+        <repository>
+            <id>lumine-repo</id>
+            <url>https://mvn.lumine.io/repository/maven-public/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -67,6 +71,17 @@
             <artifactId>paper-api</artifactId>
             <version>1.20.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.lumine</groupId>
+            <artifactId>Mythic-Dist</artifactId>
+            <version>5.5.0-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>5.0.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/org/maks/eventPlugin/EventPlugin.java
+++ b/src/main/java/org/maks/eventPlugin/EventPlugin.java
@@ -1,17 +1,111 @@
 package org.maks.eventPlugin;
 
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.command.PluginCommand;
+import org.maks.eventPlugin.command.EventCommand;
+import org.maks.eventPlugin.config.ConfigManager;
+import org.maks.eventPlugin.db.DatabaseManager;
+import org.maks.eventPlugin.eventsystem.BuffManager;
+import org.maks.eventPlugin.eventsystem.EventManager;
+import org.maks.eventPlugin.gui.PlayerProgressGUI;
+import org.maks.eventPlugin.gui.AdminRewardEditorGUI;
+import org.maks.eventPlugin.listener.AttrieItemListener;
+import org.maks.eventPlugin.listener.MythicMobProgressListener;
 
 public final class EventPlugin extends JavaPlugin {
+    private ConfigManager configManager;
+    private DatabaseManager databaseManager;
+    private java.util.Map<String, EventManager> eventManagers;
+    private BuffManager buffManager;
+    private PlayerProgressGUI progressGUI;
+    private AdminRewardEditorGUI rewardGUI;
 
     @Override
     public void onEnable() {
-        // Plugin startup logic
+        saveDefaultConfig();
+        configManager = new ConfigManager(this);
+        configManager.load();
 
+        String host = configManager.getString("database.host");
+        String port = configManager.getString("database.port");
+        String db = configManager.getString("database.name");
+        String user = configManager.getString("database.user");
+        String pass = configManager.getString("database.password");
+
+        databaseManager = new DatabaseManager();
+        databaseManager.connect(host, port, db, user, pass);
+        databaseManager.setupTables();
+
+        eventManagers = new java.util.HashMap<>();
+        buffManager = new BuffManager(databaseManager);
+        progressGUI = new PlayerProgressGUI();
+        rewardGUI = new AdminRewardEditorGUI();
+        loadActiveEvents();
+        loadConfiguredEvents();
+
+        getServer().getPluginManager().registerEvents(new MythicMobProgressListener(eventManagers, buffManager), this);
+        getServer().getPluginManager().registerEvents(new AttrieItemListener(this, buffManager), this);
+        getServer().getPluginManager().registerEvents(progressGUI, this);
+        getServer().getPluginManager().registerEvents(rewardGUI, this);
+
+        PluginCommand cmd = getCommand("event");
+        if (cmd != null) {
+            cmd.setExecutor(new EventCommand(eventManagers, databaseManager, progressGUI, rewardGUI));
+        } else {
+            Bukkit.getLogger().warning("Event command not found in plugin.yml");
+        }
     }
 
     @Override
     public void onDisable() {
-        // Plugin shutdown logic
+        if (databaseManager != null) databaseManager.close();
+    }
+
+    private void loadActiveEvents() {
+        try (var conn = databaseManager.getConnection();
+             var ps = conn.prepareStatement("SELECT event_id FROM events WHERE active=1")) {
+            try (var rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    String id = rs.getString(1);
+                    eventManagers.put(id, new EventManager(databaseManager, id));
+                }
+            }
+        } catch (Exception ignored) {
+        }
+    }
+
+    private void loadConfiguredEvents() {
+        var sec = configManager.getSection("events");
+        if (sec == null) return;
+        for (String id : sec.getKeys(false)) {
+            var eSec = sec.getConfigurationSection(id);
+            if (eSec == null) continue;
+            boolean active = eSec.getBoolean("active", false);
+            String name = eSec.getString("name", id);
+            String desc = eSec.getString("description", "");
+            int max = eSec.getInt("max_progress", 25000);
+            int durationDays = eSec.getInt("duration_days", 0);
+
+            EventManager manager = eventManagers.get(id);
+            if (manager == null) {
+                manager = new EventManager(databaseManager, id);
+                eventManagers.put(id, manager);
+            }
+
+            var dropSec = eSec.getConfigurationSection("drop_chances");
+            if (dropSec != null) {
+                java.util.Map<Integer, Double> map = new java.util.HashMap<>();
+                for (String k : dropSec.getKeys(false)) {
+                    map.put(Integer.parseInt(k), dropSec.getDouble(k) / 100.0);
+                }
+                manager.setDropChances(map);
+            }
+
+            if (active) {
+                long dur = durationDays > 0 ? durationDays * 86400L : 0;
+                manager.start(name, desc, max, dur);
+            }
+        }
     }
 }

--- a/src/main/java/org/maks/eventPlugin/command/EventCommand.java
+++ b/src/main/java/org/maks/eventPlugin/command/EventCommand.java
@@ -1,0 +1,93 @@
+package org.maks.eventPlugin.command;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.maks.eventPlugin.db.DatabaseManager;
+import org.maks.eventPlugin.eventsystem.EventManager;
+import org.maks.eventPlugin.gui.AdminRewardEditorGUI;
+import org.maks.eventPlugin.gui.PlayerProgressGUI;
+
+import java.util.Map;
+
+public class EventCommand implements CommandExecutor {
+    private final Map<String, EventManager> events;
+    private final DatabaseManager database;
+    private final PlayerProgressGUI progressGUI;
+    private final AdminRewardEditorGUI rewardGUI;
+
+    public EventCommand(Map<String, EventManager> events, DatabaseManager database, PlayerProgressGUI progressGUI, AdminRewardEditorGUI rewardGUI) {
+        this.events = events;
+        this.database = database;
+        this.progressGUI = progressGUI;
+        this.rewardGUI = rewardGUI;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length == 0) return false;
+        switch (args[0].toLowerCase()) {
+            case "start" -> {
+                if (!sender.hasPermission("eventplugin.admin")) return true;
+                if (args.length < 3) {
+                    sender.sendMessage("Usage: /event start <id> <durationSeconds> [maxProgress]");
+                    return true;
+                }
+                String id = args[1];
+                long duration = Long.parseLong(args[2]);
+                int max = args.length >= 4 ? Integer.parseInt(args[3]) : 25000;
+                EventManager manager = events.computeIfAbsent(id, k -> new EventManager(database, k));
+                manager.start(id, "", max, duration);
+                sender.sendMessage("Started event " + id);
+            }
+            case "stop" -> {
+                if (!sender.hasPermission("eventplugin.admin")) return true;
+                if (args.length < 2) {
+                    sender.sendMessage("Usage: /event stop <id>");
+                    return true;
+                }
+                String id = args[1];
+                EventManager m = events.get(id);
+                if (m != null) {
+                    m.stop();
+                    sender.sendMessage("Stopped event " + id);
+                } else {
+                    sender.sendMessage("Event not found: " + id);
+                }
+            }
+            case "gui" -> {
+                if (!(sender instanceof Player player)) return true;
+                String id = args.length >= 2 ? args[1] : events.keySet().stream().findFirst().orElse(null);
+                if (id == null) {
+                    player.sendMessage("No active event.");
+                    return true;
+                }
+                EventManager m = events.get(id);
+                if (m == null || !m.isActive()) {
+                    player.sendMessage("Event not active.");
+                    return true;
+                }
+                m.checkExpiry();
+                if (!m.isActive()) {
+                    player.sendMessage("Event expired.");
+                    return true;
+                }
+                progressGUI.open(player, m);
+            }
+            case "rewards" -> {
+                if (!(sender instanceof Player player)) return true;
+                if (!sender.hasPermission("eventplugin.admin")) return true;
+                if (args.length < 2) {
+                    player.sendMessage("Usage: /event rewards <id>");
+                    return true;
+                }
+                String id = args[1];
+                EventManager manager = events.computeIfAbsent(id, k -> new EventManager(database, k));
+                rewardGUI.open(player, manager);
+            }
+            default -> sender.sendMessage("Unknown subcommand");
+        }
+        return true;
+    }
+}

--- a/src/main/java/org/maks/eventPlugin/config/ConfigManager.java
+++ b/src/main/java/org/maks/eventPlugin/config/ConfigManager.java
@@ -1,0 +1,60 @@
+package org.maks.eventPlugin.config;
+
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import org.bukkit.configuration.ConfigurationSection;
+
+import java.io.File;
+import java.io.IOException;
+
+public class ConfigManager {
+    private final JavaPlugin plugin;
+    private FileConfiguration config;
+
+    public ConfigManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public void load() {
+        File configFile = new File(plugin.getDataFolder(), "config.yml");
+        if (!configFile.exists()) {
+            configFile.getParentFile().mkdirs();
+            plugin.saveResource("config.yml", false);
+        }
+        config = YamlConfiguration.loadConfiguration(configFile);
+    }
+
+    public FileConfiguration getConfig() {
+        return config;
+    }
+
+    public String getString(String path) {
+        return config.getString(path);
+    }
+
+    public boolean getBoolean(String path) {
+        return config.getBoolean(path);
+    }
+
+    public int getInt(String path) {
+        return config.getInt(path);
+    }
+
+    public void set(String path, Object value) {
+        config.set(path, value);
+        try {
+            config.save(new File(plugin.getDataFolder(), "config.yml"));
+        } catch (IOException ignored) {
+        }
+    }
+
+    public ConfigurationSection getSection(String path) {
+        return config.getConfigurationSection(path);
+    }
+
+    public void reload() {
+        load();
+    }
+}

--- a/src/main/java/org/maks/eventPlugin/db/DatabaseManager.java
+++ b/src/main/java/org/maks/eventPlugin/db/DatabaseManager.java
@@ -1,0 +1,70 @@
+package org.maks.eventPlugin.db;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.bukkit.Bukkit;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public class DatabaseManager {
+    private HikariDataSource dataSource;
+
+    public void connect(String host, String port, String database, String user, String password) {
+        HikariConfig config = new HikariConfig();
+        config.setJdbcUrl("jdbc:mysql://" + host + ":" + port + "/" + database + "?useSSL=false&allowPublicKeyRetrieval=true");
+        config.setUsername(user);
+        config.setPassword(password);
+        config.addDataSourceProperty("cachePrepStmts", "true");
+        config.addDataSourceProperty("prepStmtCacheSize", "250");
+        config.addDataSourceProperty("prepStmtCacheSqlLimit", "2048");
+        dataSource = new HikariDataSource(config);
+        Bukkit.getLogger().info("[EventPlugin] Connected to MySQL");
+    }
+
+    public Connection getConnection() throws SQLException {
+        return dataSource.getConnection();
+    }
+
+    /**
+     * Create tables used by the plugin if they don't exist.
+     */
+    public void setupTables() {
+        try (Connection conn = getConnection();
+             var st = conn.createStatement()) {
+            st.executeUpdate("CREATE TABLE IF NOT EXISTS events(" +
+                    "event_id VARCHAR(100) PRIMARY KEY," +
+                    "name VARCHAR(100)," +
+                    "description TEXT," +
+                    "end_time BIGINT," +
+                    "max_progress INT," +
+                    "active BOOLEAN DEFAULT 0)");
+            st.executeUpdate("CREATE TABLE IF NOT EXISTS event_progress(" +
+                    "event_id VARCHAR(100)," +
+                    "player_uuid VARCHAR(36)," +
+                    "progress INT NOT NULL," +
+                    "PRIMARY KEY(event_id, player_uuid))");
+            st.executeUpdate("CREATE TABLE IF NOT EXISTS event_rewards(" +
+                    "event_id VARCHAR(100)," +
+                    "required INT," +
+                    "item TEXT NOT NULL," +
+                    "PRIMARY KEY(event_id, required))");
+            st.executeUpdate("CREATE TABLE IF NOT EXISTS event_claimed(" +
+                    "event_id VARCHAR(100)," +
+                    "player_uuid VARCHAR(36)," +
+                    "reward INT," +
+                    "PRIMARY KEY(event_id, player_uuid, reward))");
+            st.executeUpdate("CREATE TABLE IF NOT EXISTS event_buffs(" +
+                    "player_uuid VARCHAR(36) PRIMARY KEY," +
+                    "buff_end BIGINT NOT NULL)");
+        } catch (SQLException ex) {
+            Bukkit.getLogger().severe("[EventPlugin] Could not setup database tables: " + ex.getMessage());
+        }
+    }
+
+    public void close() {
+        if (dataSource != null) {
+            dataSource.close();
+        }
+    }
+}

--- a/src/main/java/org/maks/eventPlugin/eventsystem/BuffManager.java
+++ b/src/main/java/org/maks/eventPlugin/eventsystem/BuffManager.java
@@ -1,0 +1,66 @@
+package org.maks.eventPlugin.eventsystem;
+
+import org.bukkit.entity.Player;
+import org.maks.eventPlugin.db.DatabaseManager;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Manages the attrie buff for players.
+ */
+import java.sql.SQLException;
+
+public class BuffManager {
+    private final Map<UUID, Instant> buffEnd = new HashMap<>();
+    private final DatabaseManager database;
+
+    public BuffManager(DatabaseManager database) {
+        this.database = database;
+        loadBuffs();
+    }
+
+    public boolean hasBuff(Player player) {
+        Instant end = buffEnd.get(player.getUniqueId());
+        return end != null && end.isAfter(Instant.now());
+    }
+
+    public void applyBuff(Player player, int days) {
+        Instant end = Instant.now().plusSeconds(days * 24L * 3600L);
+        buffEnd.put(player.getUniqueId(), end);
+        saveBuff(player.getUniqueId(), end);
+    }
+
+    private void loadBuffs() {
+        try (var conn = database.getConnection();
+             var ps = conn.prepareStatement("SELECT player_uuid, buff_end FROM event_buffs")) {
+            try (var rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    UUID id = UUID.fromString(rs.getString(1));
+                    long end = rs.getLong(2);
+                    if (end > 0) buffEnd.put(id, Instant.ofEpochMilli(end));
+                }
+            }
+        } catch (SQLException ignored) {
+        }
+    }
+
+    private void saveBuff(UUID uuid, Instant end) {
+        long millis = end.toEpochMilli();
+        try (var conn = database.getConnection();
+             var ps = conn.prepareStatement("UPDATE event_buffs SET buff_end=? WHERE player_uuid=?")) {
+            ps.setLong(1, millis);
+            ps.setString(2, uuid.toString());
+            if (ps.executeUpdate() == 0) {
+                try (var ins = conn.prepareStatement("INSERT INTO event_buffs(player_uuid, buff_end) VALUES (?,?)")) {
+                    ins.setString(1, uuid.toString());
+                    ins.setLong(2, millis);
+                    ins.executeUpdate();
+                }
+            }
+        } catch (SQLException ignored) {
+        }
+    }
+}

--- a/src/main/java/org/maks/eventPlugin/eventsystem/EventManager.java
+++ b/src/main/java/org/maks/eventPlugin/eventsystem/EventManager.java
@@ -1,0 +1,279 @@
+package org.maks.eventPlugin.eventsystem;
+
+import org.bukkit.entity.Player;
+import org.maks.eventPlugin.db.DatabaseManager;
+import org.maks.eventPlugin.util.ItemUtil;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.List;
+import java.util.ArrayList;
+import org.bukkit.inventory.ItemStack;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
+
+public class EventManager {
+    private final DatabaseManager database;
+    private final String eventId;
+    private boolean active;
+    private int maxProgress;
+    private String name;
+    private String description;
+    private long endTime;
+    private final Map<UUID, Integer> progressMap = new HashMap<>();
+    private final Map<UUID, java.util.Set<Integer>> claimedMap = new HashMap<>();
+    private final List<Reward> rewards = new ArrayList<>();
+    private Map<Integer, Double> dropChances = new HashMap<>();
+
+    public EventManager(DatabaseManager database, String eventId) {
+        this.database = database;
+        this.eventId = eventId;
+        loadEvent();
+        loadRewards();
+        loadProgress();
+    }
+
+    public void setDropChances(Map<Integer, Double> chances) {
+        this.dropChances = chances;
+    }
+
+    public int getRandomProgress() {
+        if (dropChances == null || dropChances.isEmpty()) {
+            return java.util.concurrent.ThreadLocalRandom.current().nextInt(0, 6);
+        }
+        double rnd = java.util.concurrent.ThreadLocalRandom.current().nextDouble();
+        double cumulative = 0.0;
+        for (var entry : dropChances.entrySet()) {
+            cumulative += entry.getValue();
+            if (rnd <= cumulative) return entry.getKey();
+        }
+        return 0;
+    }
+    public boolean isActive() {
+        return active;
+    }
+
+    public void toggle() {
+        active = !active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+
+    public void setMaxProgress(int max) {
+        this.maxProgress = max;
+    }
+
+    public int getMaxProgress() {
+        return maxProgress;
+    }
+
+    public int getProgress(Player player) {
+        return progressMap.getOrDefault(player.getUniqueId(), 0);
+    }
+
+    public void addProgress(Player player, int amount, double multiplier) {
+        int current = progressMap.getOrDefault(player.getUniqueId(), 0);
+        int newProgress = current + (int) Math.round(amount * multiplier);
+        if (newProgress > maxProgress) newProgress = maxProgress;
+        progressMap.put(player.getUniqueId(), newProgress);
+        saveProgress(player.getUniqueId(), newProgress);
+    }
+
+    public void addReward(int required, ItemStack item) {
+        rewards.add(new Reward(required, item));
+        saveReward(required, item);
+    }
+
+    public void setRewards(List<Reward> newRewards) {
+        clearRewards();
+        for (Reward r : newRewards) {
+            addReward(r.requiredProgress(), r.item());
+        }
+    }
+
+    private void clearRewards() {
+        rewards.clear();
+        try (var conn = database.getConnection();
+             var ps = conn.prepareStatement("DELETE FROM event_rewards WHERE event_id=?")) {
+            ps.setString(1, eventId);
+            ps.executeUpdate();
+        } catch (SQLException ignored) {
+        }
+    }
+
+    public List<Reward> getRewards() {
+        return rewards;
+    }
+
+    public boolean claimReward(Player player, int required) {
+        int progress = getProgress(player);
+        if (progress < required) return false;
+        var set = claimedMap.computeIfAbsent(player.getUniqueId(), k -> new java.util.HashSet<>());
+        if (set.contains(required)) return false;
+        set.add(required);
+        saveClaimed(player.getUniqueId(), required);
+        return true;
+    }
+
+    private void loadProgress() {
+        try (var conn = database.getConnection();
+             var ps = conn.prepareStatement("SELECT player_uuid, progress FROM event_progress WHERE event_id=?")) {
+            ps.setString(1, eventId);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    UUID id = UUID.fromString(rs.getString(1));
+                    int prog = rs.getInt(2);
+                    progressMap.put(id, prog);
+                }
+            }
+        } catch (SQLException ignored) {
+        }
+        // load claimed rewards
+        try (var conn = database.getConnection();
+             var ps = conn.prepareStatement("SELECT player_uuid, reward FROM event_claimed WHERE event_id=?")) {
+            ps.setString(1, eventId);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    UUID id = UUID.fromString(rs.getString(1));
+                    int rew = rs.getInt(2);
+                    claimedMap.computeIfAbsent(id, k -> new java.util.HashSet<>()).add(rew);
+                }
+            }
+        } catch (SQLException ignored) {
+        }
+    }
+
+    private void saveProgress(UUID uuid, int progress) {
+        try (var conn = database.getConnection();
+             var ps = conn.prepareStatement("REPLACE INTO event_progress(event_id, player_uuid, progress) VALUES (?,?,?)")) {
+            ps.setString(1, eventId);
+            ps.setString(2, uuid.toString());
+            ps.setInt(3, progress);
+            ps.executeUpdate();
+        } catch (SQLException ignored) {
+        }
+    }
+
+    private void loadRewards() {
+        try (var conn = database.getConnection();
+             var ps = conn.prepareStatement("SELECT required, item FROM event_rewards WHERE event_id=?")) {
+            ps.setString(1, eventId);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    int req = rs.getInt(1);
+                    String data = rs.getString(2);
+                    ItemStack item = ItemUtil.deserialize(data);
+                    if (item != null)
+                        rewards.add(new Reward(req, item));
+                }
+            }
+        } catch (SQLException ignored) {
+        }
+    }
+
+    private void saveReward(int required, ItemStack item) {
+        String data = ItemUtil.serialize(item);
+        if (data == null) return;
+        try (var conn = database.getConnection();
+             var ps = conn.prepareStatement("REPLACE INTO event_rewards(event_id, required, item) VALUES (?,?,?)")) {
+            ps.setString(1, eventId);
+            ps.setInt(2, required);
+            ps.setString(3, data);
+            ps.executeUpdate();
+        } catch (SQLException ignored) {
+        }
+    }
+
+    private void saveClaimed(UUID uuid, int reward) {
+        try (var conn = database.getConnection();
+             var ps = conn.prepareStatement("REPLACE INTO event_claimed(event_id, player_uuid, reward) VALUES (?,?,?)")) {
+            ps.setString(1, eventId);
+            ps.setString(2, uuid.toString());
+            ps.setInt(3, reward);
+            ps.executeUpdate();
+        } catch (SQLException ignored) {
+        }
+    }
+
+    /* Load basic event info from database */
+    private void loadEvent() {
+        try (var conn = database.getConnection();
+             var ps = conn.prepareStatement("SELECT name, description, end_time, max_progress, active FROM events WHERE event_id=?")) {
+            ps.setString(1, eventId);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    name = rs.getString(1);
+                    description = rs.getString(2);
+                    endTime = rs.getLong(3);
+                    maxProgress = rs.getInt(4);
+                    active = rs.getBoolean(5);
+                } else {
+                    // defaults if not defined
+                    name = eventId;
+                    description = "";
+                    endTime = 0L;
+                    maxProgress = 25000;
+                    active = false;
+                    saveEvent();
+                }
+            }
+        } catch (SQLException ignored) {
+        }
+    }
+
+    private void saveEvent() {
+        try (var conn = database.getConnection();
+             var ps = conn.prepareStatement("REPLACE INTO events(event_id, name, description, end_time, max_progress, active) VALUES (?,?,?,?,?,?)")) {
+            ps.setString(1, eventId);
+            ps.setString(2, name);
+            ps.setString(3, description);
+            ps.setLong(4, endTime);
+            ps.setInt(5, maxProgress);
+            ps.setBoolean(6, active);
+            ps.executeUpdate();
+        } catch (SQLException ignored) {
+        }
+    }
+
+    public void start(String name, String description, int maxProgress, long durationSeconds) {
+        this.name = name;
+        this.description = description;
+        this.maxProgress = maxProgress;
+        this.endTime = Instant.now().plusSeconds(durationSeconds).toEpochMilli();
+        this.active = true;
+        saveEvent();
+    }
+
+    public void stop() {
+        this.active = false;
+        saveEvent();
+    }
+
+    public void checkExpiry() {
+        if (active && endTime > 0 && Instant.now().toEpochMilli() >= endTime) {
+            active = false;
+            saveEvent();
+        }
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public long getEndTime() {
+        return endTime;
+    }
+
+    public long getTimeRemaining() {
+        return Math.max(0, endTime - Instant.now().toEpochMilli());
+    }
+}

--- a/src/main/java/org/maks/eventPlugin/eventsystem/Reward.java
+++ b/src/main/java/org/maks/eventPlugin/eventsystem/Reward.java
@@ -1,0 +1,6 @@
+package org.maks.eventPlugin.eventsystem;
+
+import org.bukkit.inventory.ItemStack;
+
+public record Reward(int requiredProgress, ItemStack item) {
+}

--- a/src/main/java/org/maks/eventPlugin/gui/AdminRewardEditorGUI.java
+++ b/src/main/java/org/maks/eventPlugin/gui/AdminRewardEditorGUI.java
@@ -1,0 +1,120 @@
+package org.maks.eventPlugin.gui;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.maks.eventPlugin.eventsystem.EventManager;
+import org.maks.eventPlugin.eventsystem.Reward;
+
+import java.util.*;
+
+public class AdminRewardEditorGUI implements Listener {
+    private final Map<UUID, Session> sessions = new HashMap<>();
+
+    private static class Session {
+        enum Stage { ADD_ITEMS, SET_PROGRESS }
+        Stage stage;
+        Inventory inventory;
+        List<ItemStack> rewards = new ArrayList<>();
+        List<Integer> progress = new ArrayList<>();
+        EventManager eventManager;
+    }
+
+    public AdminRewardEditorGUI() {
+    }
+
+    public void open(Player player, EventManager manager) {
+        Session session = new Session();
+        session.eventManager = manager;
+        session.stage = Session.Stage.ADD_ITEMS;
+        Inventory inv = Bukkit.createInventory(player, 27, "Reward Items");
+        ItemStack next = new ItemStack(Material.LIME_WOOL);
+        ItemMeta meta = next.getItemMeta();
+        meta.setDisplayName("Next");
+        next.setItemMeta(meta);
+        inv.setItem(26, next);
+        session.inventory = inv;
+        sessions.put(player.getUniqueId(), session);
+        player.openInventory(inv);
+    }
+
+    private void openProgressStage(Player player, Session session) {
+        session.stage = Session.Stage.SET_PROGRESS;
+        int rows = ((session.rewards.size() - 1) / 9 + 1) + 1; // extra row for save
+        Inventory inv = Bukkit.createInventory(player, rows * 9, "Reward Progress");
+        session.progress = new ArrayList<>(Collections.nCopies(session.rewards.size(), 0));
+        for (int i = 0; i < session.rewards.size(); i++) {
+            ItemStack item = session.rewards.get(i).clone();
+            ItemMeta meta = item.getItemMeta();
+            meta.setLore(List.of("Required: 0", "Left/Right click to edit"));
+            item.setItemMeta(meta);
+            inv.setItem(i, item);
+        }
+        ItemStack save = new ItemStack(Material.GREEN_WOOL);
+        ItemMeta meta = save.getItemMeta();
+        meta.setDisplayName("Save");
+        save.setItemMeta(meta);
+        inv.setItem(inv.getSize() - 1, save);
+        session.inventory = inv;
+        player.openInventory(inv);
+    }
+
+    @EventHandler
+    public void onClick(InventoryClickEvent event) {
+        Player player = (Player) event.getWhoClicked();
+        Session session = sessions.get(player.getUniqueId());
+        if (session == null || event.getInventory() != session.inventory) return;
+        event.setCancelled(true);
+        int slot = event.getRawSlot();
+        if (session.stage == Session.Stage.ADD_ITEMS) {
+            if (slot == 26) {
+                for (int i = 0; i < 26; i++) {
+                    ItemStack it = session.inventory.getItem(i);
+                    if (it != null && it.getType() != Material.AIR) {
+                        session.rewards.add(it.clone());
+                    }
+                }
+                openProgressStage(player, session);
+            } else if (slot < 26) {
+                // allow placing/removing items
+                event.setCancelled(false);
+            }
+        } else if (session.stage == Session.Stage.SET_PROGRESS) {
+            if (slot == session.inventory.getSize() - 1) {
+                // save
+                List<Reward> rewards = new ArrayList<>();
+                for (int i = 0; i < session.rewards.size(); i++) {
+                    rewards.add(new Reward(session.progress.get(i), session.rewards.get(i)));
+                }
+                session.eventManager.setRewards(rewards);
+                player.sendMessage("Rewards saved.");
+                player.closeInventory();
+                sessions.remove(player.getUniqueId());
+            } else if (slot < session.rewards.size()) {
+                int prog = session.progress.get(slot);
+                if (event.isLeftClick()) prog += 100;
+                else if (event.isRightClick()) prog = Math.max(0, prog - 100);
+                session.progress.set(slot, prog);
+                ItemStack item = session.inventory.getItem(slot);
+                if (item != null) {
+                    ItemMeta meta = item.getItemMeta();
+                    meta.setLore(List.of("Required: " + prog, "Left/Right click to edit"));
+                    item.setItemMeta(meta);
+                    session.inventory.setItem(slot, item);
+                }
+            }
+        }
+    }
+
+    @EventHandler
+    public void onClose(InventoryCloseEvent event) {
+        sessions.remove(event.getPlayer().getUniqueId());
+    }
+}

--- a/src/main/java/org/maks/eventPlugin/gui/PlayerProgressGUI.java
+++ b/src/main/java/org/maks/eventPlugin/gui/PlayerProgressGUI.java
@@ -1,0 +1,103 @@
+package org.maks.eventPlugin.gui;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.maks.eventPlugin.eventsystem.EventManager;
+import org.maks.eventPlugin.util.TimeUtil;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class PlayerProgressGUI implements Listener {
+    private static class Session {
+        Inventory inv;
+        EventManager manager;
+    }
+
+    private final Map<UUID, Session> open = new HashMap<>();
+
+    public PlayerProgressGUI() {
+    }
+
+    public void open(Player player, EventManager eventManager) {
+        int size = 27;
+        Inventory inv = Bukkit.createInventory(null, size, "Event Progress");
+
+        int progress = eventManager.getProgress(player);
+        int max = eventManager.getMaxProgress();
+        int filledSlots = (int) ((double) progress / max * (size - 9));
+
+        ItemStack filled = new ItemStack(Material.YELLOW_STAINED_GLASS_PANE);
+        ItemMeta meta = filled.getItemMeta();
+        meta.setDisplayName("§eProgress " + progress + " / " + max);
+        filled.setItemMeta(meta);
+
+        ItemStack empty = new ItemStack(Material.BLACK_STAINED_GLASS_PANE);
+
+        for (int i = 0; i < size - 9; i++) {
+            inv.setItem(i, i < filledSlots ? filled : empty);
+        }
+
+        ItemStack info = new ItemStack(Material.PAPER);
+        ItemMeta infoMeta = info.getItemMeta();
+        infoMeta.setDisplayName("§b" + eventManager.getName());
+        infoMeta.setLore(java.util.List.of(
+                eventManager.getDescription(),
+                "Ends in: " + TimeUtil.formatDuration(eventManager.getTimeRemaining())
+        ));
+        info.setItemMeta(infoMeta);
+        inv.setItem(size - 1, info);
+
+        int index = size - 9;
+        for (var reward : eventManager.getRewards()) {
+            ItemStack rewardItem = reward.item().clone();
+            ItemMeta m = rewardItem.getItemMeta();
+            m.setDisplayName("§6Reward at " + reward.requiredProgress());
+            m.setLore(java.util.List.of("Requires: " + reward.requiredProgress()));
+            rewardItem.setItemMeta(m);
+            inv.setItem(index++, rewardItem);
+            if (index >= size - 1) break;
+        }
+
+        Session session = new Session();
+        session.inv = inv;
+        session.manager = eventManager;
+        open.put(player.getUniqueId(), session);
+        player.openInventory(inv);
+    }
+
+    @EventHandler
+    public void onClick(InventoryClickEvent event) {
+        Player player = (Player) event.getWhoClicked();
+        Session session = open.get(player.getUniqueId());
+        if (session == null || !event.getInventory().equals(session.inv)) return;
+        EventManager eventManager = session.manager;
+        event.setCancelled(true);
+        ItemStack item = event.getCurrentItem();
+        if (item == null) return;
+        for (var reward : eventManager.getRewards()) {
+            if (item.isSimilar(reward.item())) {
+                if (eventManager.claimReward(player, reward.requiredProgress())) {
+                    player.getInventory().addItem(reward.item().clone());
+                    player.sendMessage("§aReward claimed!");
+                } else {
+                    player.sendMessage("§cYou cannot claim this reward yet.");
+                }
+                break;
+            }
+        }
+    }
+
+    @EventHandler
+    public void onClose(org.bukkit.event.inventory.InventoryCloseEvent event) {
+        open.remove(event.getPlayer().getUniqueId());
+    }
+}

--- a/src/main/java/org/maks/eventPlugin/listener/AttrieItemListener.java
+++ b/src/main/java/org/maks/eventPlugin/listener/AttrieItemListener.java
@@ -1,0 +1,35 @@
+package org.maks.eventPlugin.listener;
+
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.NamespacedKey;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.maks.eventPlugin.eventsystem.BuffManager;
+
+public class AttrieItemListener implements Listener {
+    private final BuffManager buffManager;
+    private final NamespacedKey key;
+
+    public AttrieItemListener(JavaPlugin plugin, BuffManager buffManager) {
+        this.buffManager = buffManager;
+        this.key = new NamespacedKey(plugin, "attrie-item");
+    }
+
+    @EventHandler
+    public void onInteract(PlayerInteractEvent event) {
+        Player player = event.getPlayer();
+        ItemStack item = event.getItem();
+        if (item == null || item.getType() == Material.AIR) return;
+        if (item.getItemMeta() != null && item.getItemMeta().getPersistentDataContainer().has(key, PersistentDataType.INTEGER)) {
+            event.setCancelled(true);
+            item.setAmount(item.getAmount() - 1);
+            buffManager.applyBuff(player, 30);
+            player.sendMessage("§aEvent Attrie activated for 30 days!");
+        }
+    }
+}

--- a/src/main/java/org/maks/eventPlugin/listener/MythicMobProgressListener.java
+++ b/src/main/java/org/maks/eventPlugin/listener/MythicMobProgressListener.java
@@ -1,0 +1,33 @@
+package org.maks.eventPlugin.listener;
+
+import io.lumine.mythic.bukkit.events.MythicMobDeathEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.entity.Player;
+import org.maks.eventPlugin.eventsystem.BuffManager;
+import org.maks.eventPlugin.eventsystem.EventManager;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+public class MythicMobProgressListener implements Listener {
+    private final java.util.Map<String, EventManager> events;
+    private final BuffManager buffManager;
+
+    public MythicMobProgressListener(java.util.Map<String, EventManager> events, BuffManager buffManager) {
+        this.events = events;
+        this.buffManager = buffManager;
+    }
+
+    @EventHandler
+    public void onMobDeath(MythicMobDeathEvent event) {
+        if (!(event.getKiller() instanceof Player player)) return;
+        double multiplier = buffManager.hasBuff(player) ? 1.5 : 1.0;
+        for (EventManager manager : events.values()) {
+            manager.checkExpiry();
+            if (manager.isActive()) {
+                int amount = manager.getRandomProgress();
+                manager.addProgress(player, amount, multiplier);
+            }
+        }
+    }
+}

--- a/src/main/java/org/maks/eventPlugin/util/ItemUtil.java
+++ b/src/main/java/org/maks/eventPlugin/util/ItemUtil.java
@@ -1,0 +1,46 @@
+package org.maks.eventPlugin.util;
+
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.util.io.BukkitObjectInputStream;
+import org.bukkit.util.io.BukkitObjectOutputStream;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Base64;
+
+public class ItemUtil {
+    public static ItemStack createAttrieItem(JavaPlugin plugin) {
+        ItemStack item = new ItemStack(Material.POTATO);
+        ItemMeta meta = item.getItemMeta();
+        meta.setDisplayName("§3Event Attrie");
+        meta.getPersistentDataContainer().set(new NamespacedKey(plugin, "attrie-item"), PersistentDataType.INTEGER, 1);
+        meta.setUnbreakable(true);
+        item.setItemMeta(meta);
+        return item;
+    }
+
+    public static String serialize(ItemStack item) {
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream();
+             BukkitObjectOutputStream dataOut = new BukkitObjectOutputStream(out)) {
+            dataOut.writeObject(item);
+            return Base64.getEncoder().encodeToString(out.toByteArray());
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    public static ItemStack deserialize(String data) {
+        try (ByteArrayInputStream in = new ByteArrayInputStream(Base64.getDecoder().decode(data));
+             BukkitObjectInputStream dataIn = new BukkitObjectInputStream(in)) {
+            return (ItemStack) dataIn.readObject();
+        } catch (ClassNotFoundException | IOException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/maks/eventPlugin/util/TimeUtil.java
+++ b/src/main/java/org/maks/eventPlugin/util/TimeUtil.java
@@ -1,0 +1,13 @@
+package org.maks.eventPlugin.util;
+
+public class TimeUtil {
+    public static String formatDuration(long millis) {
+        long seconds = Math.max(0, millis / 1000);
+        long days = seconds / 86400;
+        seconds %= 86400;
+        long hours = seconds / 3600;
+        seconds %= 3600;
+        long minutes = seconds / 60;
+        return days + "d " + hours + "h " + minutes + "m";
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,20 @@
+database:
+  host: localhost
+  port: "3306"
+  name: database
+  user: user
+  password: pass
+
+events:
+  "1":
+    name: "Monster Hunt"
+    active: true
+    duration_days: 14
+    max_progress: 12000
+    description: "Monster hunt has begun, kill all monsters to get rewards."
+    drop_chances:
+      "0": 75
+      "1": 10
+      "2": 10
+      "3": 3
+      "5": 2

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -2,3 +2,7 @@ name: eventPlugin
 version: '1.0-SNAPSHOT'
 main: org.maks.eventPlugin.EventPlugin
 api-version: '1.20'
+commands:
+  event:
+    description: Main event command
+    usage: /event <start|stop|gui|rewards>


### PR DESCRIPTION
## Summary
- load events from `config.yml` on startup
- support per-event progress drop chances
- expose config sections and reload for ConfigManager
- show config example in README
- add sample "Monster Hunt" event to config

## Testing
- `mvn -q -DskipTests package` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_68887049dc78832a9981f28ae6129245