### PR TITLE
Fix reward slot placement and show attrie buff

### DIFF
--- a/src/main/java/org/maks/eventPlugin/EventPlugin.java
+++ b/src/main/java/org/maks/eventPlugin/EventPlugin.java
@@ -40,7 +40,7 @@ public final class EventPlugin extends JavaPlugin {
 
         eventManagers = new java.util.HashMap<>();
         buffManager = new BuffManager(databaseManager);
-        progressGUI = new PlayerProgressGUI();
+        progressGUI = new PlayerProgressGUI(buffManager);
         rewardGUI = new AdminRewardEditorGUI();
         loadActiveEvents();
         loadConfiguredEvents();

--- a/src/main/java/org/maks/eventPlugin/eventsystem/BuffManager.java
+++ b/src/main/java/org/maks/eventPlugin/eventsystem/BuffManager.java
@@ -27,6 +27,17 @@ public class BuffManager {
         return end != null && end.isAfter(Instant.now());
     }
 
+    /**
+     * Get remaining buff duration for the given player in milliseconds.
+     * Returns 0 if the player has no active buff.
+     */
+    public long getRemaining(Player player) {
+        Instant end = buffEnd.get(player.getUniqueId());
+        if (end == null) return 0L;
+        long remaining = end.toEpochMilli() - Instant.now().toEpochMilli();
+        return Math.max(0L, remaining);
+    }
+
     public void applyBuff(Player player, int days) {
         Instant end = Instant.now().plusSeconds(days * 24L * 3600L);
         buffEnd.put(player.getUniqueId(), end);

--- a/src/main/java/org/maks/eventPlugin/gui/PlayerProgressGUI.java
+++ b/src/main/java/org/maks/eventPlugin/gui/PlayerProgressGUI.java
@@ -11,6 +11,7 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.maks.eventPlugin.eventsystem.EventManager;
+import org.maks.eventPlugin.eventsystem.BuffManager;
 import org.maks.eventPlugin.util.TimeUtil;
 
 import java.util.*;
@@ -68,6 +69,11 @@ public class PlayerProgressGUI implements Listener {
     }
 
     private final Map<UUID, Session> open = new HashMap<>();
+    private final BuffManager buffManager;
+
+    public PlayerProgressGUI(BuffManager buffManager) {
+        this.buffManager = buffManager;
+    }
 
     public void open(Player player, EventManager eventManager) {
         int progress = eventManager.getProgress(player);
@@ -114,6 +120,20 @@ public class PlayerProgressGUI implements Listener {
         info.setItemMeta(infoMeta);
         inv.setItem(53, info);
 
+        boolean attrie = buffManager.hasBuff(player);
+        ItemStack attrieItem = new ItemStack(Material.PAPER);
+        ItemMeta am = attrieItem.getItemMeta();
+        am.setDisplayName("§dAttrie bonus: " + (attrie ? "ON" : "OFF"));
+        List<String> aLore = new ArrayList<>();
+        if (attrie) {
+            aLore.add("Remaining: " + TimeUtil.formatDuration(buffManager.getRemaining(player)));
+        } else {
+            aLore.add("Not active");
+        }
+        am.setLore(aLore);
+        attrieItem.setItemMeta(am);
+        inv.setItem(45, attrieItem);
+
         Session session = new Session();
         session.inv = inv;
         session.manager = eventManager;
@@ -121,7 +141,8 @@ public class PlayerProgressGUI implements Listener {
 
         Set<Integer> usedReward = new HashSet<>();
         for (var reward : eventManager.getRewards()) {
-            int pathIndex = (int) Math.floor(reward.requiredProgress() / perSlot);
+            int pathIndex = (int) Math.ceil(reward.requiredProgress() / perSlot) - 1;
+            if (pathIndex < 0) pathIndex = 0;
             if (pathIndex >= PATH_SLOTS.size()) pathIndex = PATH_SLOTS.size() - 1;
             List<Integer> candidates = PATH_TO_REWARD.get(pathIndex);
             int slot = -1;

--- a/src/main/java/org/maks/eventPlugin/listener/AttrieItemListener.java
+++ b/src/main/java/org/maks/eventPlugin/listener/AttrieItemListener.java
@@ -46,6 +46,8 @@ public class AttrieItemListener implements Listener {
                 player.getInventory().setItemInOffHand(updated.getAmount() > 0 ? updated : null);
             }
 
+            player.updateInventory();
+
             buffManager.applyBuff(player, 30);
             player.sendMessage("§aEvent Attrie activated for 30 days!");
         }


### PR DESCRIPTION
## Summary
- display attrie bonus status and remaining time in player GUI
- correct reward position calculation so rewards line up with progress
- wire PlayerProgressGUI with BuffManager
- refresh inventory when attrie item used

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688a28dcdc5c832aa38dc24cc8810752