### PR TITLE
Fix attrie item consumption

### DIFF
--- a/src/main/java/org/maks/eventPlugin/EventPlugin.java
+++ b/src/main/java/org/maks/eventPlugin/EventPlugin.java
@@ -41,7 +41,7 @@ public final class EventPlugin extends JavaPlugin {
         eventManagers = new java.util.HashMap<>();
         buffManager = new BuffManager(databaseManager);
         progressGUI = new PlayerProgressGUI();
-        rewardGUI = new AdminRewardEditorGUI();
+        rewardGUI = new AdminRewardEditorGUI(this);
         loadActiveEvents();
         loadConfiguredEvents();
 


### PR DESCRIPTION
## Summary
- fix attrie item consumption logic
- require right-click and update the correct hand
- allow setting reward progress with chat input
- permit dragging items into reward GUI

## Testing
- `mvn -q -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6888acc2a3b8832ab0fca61d87c42b2b