### PR TITLE
Fix reward placement and attrie item detection

### DIFF
--- a/src/main/java/org/maks/eventPlugin/gui/PlayerProgressGUI.java
+++ b/src/main/java/org/maks/eventPlugin/gui/PlayerProgressGUI.java
@@ -83,8 +83,11 @@ public class PlayerProgressGUI implements Listener {
                         shortNumber(progress) + "/" + shortNumber(max) + " - " +
                         TimeUtil.formatDuration(eventManager.getTimeRemaining()));
 
-        double perSlot = (double) max / PATH_SLOTS.size();
-        int filled = (int) Math.floor(progress / perSlot);
+        // Using purely integer math avoids floating point rounding issues when
+        // calculating which progress slots should be filled. This ensures that
+        // both the progress glass panes and reward markers line up perfectly
+        // with the configured maximum progress value.
+        int filled = (int) ((long) progress * PATH_SLOTS.size() / Math.max(1, max));
 
         ItemStack filledItem = new ItemStack(Material.YELLOW_STAINED_GLASS_PANE);
         ItemStack emptyItem = new ItemStack(Material.WHITE_STAINED_GLASS_PANE);
@@ -141,7 +144,11 @@ public class PlayerProgressGUI implements Listener {
 
         Set<Integer> usedReward = new HashSet<>();
         for (var reward : eventManager.getRewards()) {
-            int pathIndex = (int) Math.ceil(reward.requiredProgress() / perSlot) - 1;
+            // Map required progress to the index of the progress path using
+            // integer arithmetic to avoid rounding errors. The formula maps the
+            // range [0, max] to [0, PATH_SLOTS.size()-1].
+            int pathIndex = (int) (((long) reward.requiredProgress() * PATH_SLOTS.size() - 1)
+                    / Math.max(1, max));
             if (pathIndex < 0) pathIndex = 0;
             if (pathIndex >= PATH_SLOTS.size()) pathIndex = PATH_SLOTS.size() - 1;
             List<Integer> candidates = PATH_TO_REWARD.get(pathIndex);

--- a/src/main/java/org/maks/eventPlugin/listener/AttrieItemListener.java
+++ b/src/main/java/org/maks/eventPlugin/listener/AttrieItemListener.java
@@ -13,6 +13,7 @@ import org.maks.eventPlugin.eventsystem.BuffManager;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.event.block.Action;
+import org.bukkit.ChatColor;
 
 public class AttrieItemListener implements Listener {
     private final BuffManager buffManager;
@@ -33,7 +34,20 @@ public class AttrieItemListener implements Listener {
         if (item == null || item.getType() == Material.AIR) return;
 
         ItemMeta meta = item.getItemMeta();
-        if (meta != null && meta.getPersistentDataContainer().has(key, PersistentDataType.INTEGER)) {
+        boolean attrie = false;
+        if (meta != null) {
+            // Detect our attrie item either via persistent data or by name
+            // containing "event attrie" without colour codes.
+            if (meta.getPersistentDataContainer().has(key, PersistentDataType.INTEGER)) {
+                attrie = true;
+            } else if (meta.hasDisplayName()) {
+                String plain = ChatColor.stripColor(meta.getDisplayName());
+                if (plain != null && plain.toLowerCase().contains("event attrie")) {
+                    attrie = true;
+                }
+            }
+        }
+        if (attrie) {
             event.setCancelled(true);
 
             ItemStack updated = item.clone();


### PR DESCRIPTION
## Summary
- Align rewards with progress path using precise integer math
- Allow Attrie boost to trigger when item name contains `event attrie`

## Testing
- `mvn -q -e -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_688b14dcce90832a97ccd85cf03707f9