### PR TITLE
Fix reward placement, attrie item detection, and event duration persistence

### DIFF
--- a/src/main/java/org/maks/eventPlugin/EventPlugin.java
+++ b/src/main/java/org/maks/eventPlugin/EventPlugin.java
@@ -113,7 +113,7 @@ public final class EventPlugin extends JavaPlugin {
                 manager.setDropChances(map);
             }
 
-            if (active) {
+            if (active && !manager.isActive()) {
                 long dur = durationDays > 0 ? durationDays * 86400L : 0;
                 manager.start(name, desc, max, dur);
             }

--- a/src/main/java/org/maks/eventPlugin/listener/AttrieItemListener.java
+++ b/src/main/java/org/maks/eventPlugin/listener/AttrieItemListener.java
@@ -13,6 +13,7 @@ import org.maks.eventPlugin.eventsystem.BuffManager;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.event.block.Action;
+import org.bukkit.ChatColor;
 
 public class AttrieItemListener implements Listener {
     private final BuffManager buffManager;
@@ -33,7 +34,20 @@ public class AttrieItemListener implements Listener {
         if (item == null || item.getType() == Material.AIR) return;
 
         ItemMeta meta = item.getItemMeta();
-        if (meta != null && meta.getPersistentDataContainer().has(key, PersistentDataType.INTEGER)) {
+        boolean attrie = false;
+        if (meta != null) {
+            // Detect our attrie item either via persistent data or by name
+            // containing "event attrie" without colour codes.
+            if (meta.getPersistentDataContainer().has(key, PersistentDataType.INTEGER)) {
+                attrie = true;
+            } else if (meta.hasDisplayName()) {
+                String plain = ChatColor.stripColor(meta.getDisplayName());
+                if (plain != null && plain.toLowerCase().contains("event attrie")) {
+                    attrie = true;
+                }
+            }
+        }
+        if (attrie) {
             event.setCancelled(true);
 
             ItemStack updated = item.clone();


### PR DESCRIPTION
## Summary
- Align reward display with snake GUI track using explicit slot mapping
- Allow Attrie boost to trigger when item name contains `event attrie`
- Preserve running event duration across server restarts by skipping config start when already active
- Start progress path at slot 2 and wrap to slot 7 so rewards line up with the GUI's snake layout

## Testing
- `mvn -q -e -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688b14dcce90832a97ccd85cf03707f9