### PR TITLE
fix: restore original snake path

### DIFF
--- a/src/main/java/org/maks/eventPlugin/gui/PlayerProgressGUI.java
+++ b/src/main/java/org/maks/eventPlugin/gui/PlayerProgressGUI.java
@@ -23,16 +23,20 @@ public class PlayerProgressGUI implements Listener {
      * Glass panes are placed on these slots to visualize the player's progress.
      */
     private static final List<Integer> PATH_SLOTS = List.of(
-            // row 0 (left → right)
-            1, 3, 4, 5, 7,
-            // row 1 (right → left)
-            16, 14, 12, 10,
-            // row 2 (left → right)
-            19, 21, 23, 25,
-            // row 3 (right → left)
-            34, 32, 30, 28,
-            // row 4 (left → right)
-            37, 38, 39, 41, 42, 43
+            // column 1 downward
+            1, 10, 19, 28, 37,
+            // bottom row sweep to the right
+            38, 39,
+            // column 3 upward
+            30, 21, 12, 3,
+            // top row across
+            4, 5,
+            // column 5 downward
+            14, 23, 32, 41,
+            // bottom row sweep
+            42, 43,
+            // column 7 upward to finish
+            34, 25, 16, 7
     );
 
     /**
@@ -40,12 +44,14 @@ public class PlayerProgressGUI implements Listener {
      * progress slot at the same index in {@link #PATH_SLOTS}, ensuring that
      * rewards follow the snake-like layout instead of stacking vertically.
      */
-    private static final List<Integer> REWARD_PATH = List.of(
-            0, 2, 13, 6, 8,
-            15, 9, 11, 17,
-            18, 20, 22, 24,
-            33, 31, 29, 27,
-            36, 47, 40, 50, 51, 44
+    private static final List<Integer> REWARD_SLOTS = List.of(
+            0, 9, 18, 27, 36,
+            47, 48,
+            29, 20, 11, 2,
+            13, 6,
+            15, 22, 31, 50,
+            51, 52,
+            33, 24, 17, 8
     );
 
     private static class Session {
@@ -131,7 +137,6 @@ public class PlayerProgressGUI implements Listener {
         session.inv = inv;
         session.manager = eventManager;
 
-
         Set<Integer> usedReward = new HashSet<>();
         for (var reward : eventManager.getRewards()) {
             // Map required progress to the index of the progress path using
@@ -145,13 +150,13 @@ public class PlayerProgressGUI implements Listener {
             if (pathIndex >= PATH_SLOTS.size()) pathIndex = PATH_SLOTS.size() - 1;
 
             int slot = -1;
-            for (int i = pathIndex; i < REWARD_PATH.size(); i++) {
-                int candidate = REWARD_PATH.get(i);
+            for (int i = pathIndex; i < REWARD_SLOTS.size(); i++) {
+                int candidate = REWARD_SLOTS.get(i);
                 if (usedReward.add(candidate)) { slot = candidate; break; }
             }
             if (slot == -1) {
                 for (int i = pathIndex - 1; i >= 0; i--) {
-                    int candidate = REWARD_PATH.get(i);
+                    int candidate = REWARD_SLOTS.get(i);
                     if (usedReward.add(candidate)) { slot = candidate; break; }
                 }
             }


### PR DESCRIPTION
## Summary
- revert progress slot order to the original snake layout
- realign reward slot mapping with restored path so rewards follow the snake

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688b4b0f4504832a8ff5886b7719af19